### PR TITLE
Allow parsing of RemoteCommand

### DIFF
--- a/pkg/config/host_test.go
+++ b/pkg/config/host_test.go
@@ -255,6 +255,7 @@ func dummyHost() *Host {
 		PubkeyAcceptedKeyTypes:   "+ssh-dss",
 		PubkeyAuthentication:     "yes",
 		RekeyLimit:               "default none",
+		RemoteCommand:             "echo %h > /tmp/logs",
 		RemoteForward:            []string{"0.0.0.0:1234", "0.0.0.0:1235"},
 		RequestTTY:               "yes",
 		RevokedHostKeys:          "/a/revoked-keys",


### PR DESCRIPTION
The local equivalent `LocalCommand` is being parsed correctly by `assh`. This PR allows for specifying `RemoteCommand` to enable command execution on the remote machine after successfully connecting to the server.

<!-- Thank you for contributing to this repo! I'm grateful for your support -->
