### PR TITLE
include arm64 GOARCH in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ gen-release: generate
 	GOOS=linux   GOARCH=amd64 go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_linux_amd64   .
 	GOOS=linux   GOARCH=386   go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_linux_386     .
 	GOOS=linux   GOARCH=arm   go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_linux_arm     .
+	GOOS=linux   GOARCH=arm64 go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_linux_arm64   .
 	GOOS=openbsd GOARCH=amd64 go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_openbsd_amd64 .
 	GOOS=openbsd GOARCH=386   go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_openbsd_386   .
 	GOOS=openbsd GOARCH=arm   go build $(GO_INSTALL_OPTS) -i -v -o .release/assh_openbsd_arm   .


### PR DESCRIPTION
built and tested using those args in 

- go version go1.15.3 linux/arm64
- Linux 5.9.1-3-MANJARO-ARM aarch64 GNU/Linux

<!-- Thank you for contributing to this repo! I'm grateful for your support -->
