### PR TITLE
fix: write RemoteCommand to config

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1394,7 +1394,7 @@ Host toto7toto
   # KnownHostOf: toto[7-9]toto
 
 Host toutou
-  RemoteCommand  date >> /tmp/logs
+  RemoteCommand date >> /tmp/logs
   # Comment: [First line Second line Third line]
   # ResolveCommand: dig -t %h
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1394,6 +1394,7 @@ Host toto7toto
   # KnownHostOf: toto[7-9]toto
 
 Host toutou
+  RemoteCommand  date >> /tmp/logs
   # Comment: [First line Second line Third line]
   # ResolveCommand: dig -t %h
 

--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -1301,6 +1301,9 @@ func (h *Host) WriteSSHConfigTo(w io.Writer) error {
 		if h.LocalCommand != "" {
 			_, _ = fmt.Fprintf(w, "  LocalCommand %s\n", h.LocalCommand)
 		}
+		if h.RemoteCommand != "" {
+			_, _ = fmt.Fprintf(w, "  RemoteCommand %s\n", h.RemoteCommand)
+		}
 		for _, entry := range h.LocalForward {
 			_, _ = fmt.Fprintf(w, "  LocalForward %s\n", entry)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to this repo! I'm grateful for your support -->
RemoteCommand was not writing to my .ssh/config file (as LocalCommand does) because these lines are missing. Resolves issue #366 .