### PR TITLE
feat: added IdentityAgent option to Host config

### DIFF
--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -62,6 +62,7 @@ type Host struct {
 	HostKeyAlgorithms                string                    `yaml:"hostkeyalgorithms,omitempty,flow" json:"HostKeyAlgorithms,omitempty"`
 	HostKeyAlias                     string                    `yaml:"hostkeyalias,omitempty,flow" json:"HostKeyAlias,omitempty"`
 	IdentitiesOnly                   string                    `yaml:"identitiesonly,omitempty,flow" json:"IdentitiesOnly,omitempty"`
+	IdentityAgent                    string                    `yaml:"identityagent,omitempty,flow" json:"IdentityAgent,omitempty"`
 	IdentityFile                     composeyaml.Stringorslice `yaml:"identityfile,omitempty,flow" json:"IdentityFile,omitempty"`
 	IgnoreUnknown                    string                    `yaml:"ignoreunknown,omitempty,flow" json:"IgnoreUnknown,omitempty"`
 	IPQoS                            composeyaml.Stringorslice `yaml:"ipqos,omitempty,flow" json:"IPQoS,omitempty"`
@@ -378,6 +379,9 @@ func (h *Host) Options() OptionsList {
 	}
 	if h.IdentitiesOnly != "" {
 		options = append(options, Option{Name: "IdentitiesOnly", Value: h.IdentitiesOnly})
+	}
+	if h.IdentityAgent != "" {
+		options = append(options, Option{Name: "IdentityAgent", Value: h.IdentityAgent})
 	}
 	for _, entry := range h.IdentityFile {
 		options = append(options, Option{Name: "IdentityFile", Value: entry})
@@ -808,6 +812,11 @@ func (h *Host) ApplyDefaults(defaults *Host) {
 		h.IdentitiesOnly = defaults.IdentitiesOnly
 	}
 	h.IdentitiesOnly = utils.ExpandField(h.IdentitiesOnly)
+
+	if h.IdentityAgent == "" {
+		h.IdentityAgent = defaults.IdentityAgent
+	}
+	h.IdentityAgent = utils.ExpandField(h.IdentityAgent)
 
 	if len(h.IdentityFile) == 0 {
 		h.IdentityFile = defaults.IdentityFile
@@ -1285,6 +1294,9 @@ func (h *Host) WriteSSHConfigTo(w io.Writer) error {
 		}
 		if h.IdentitiesOnly != "" {
 			_, _ = fmt.Fprintf(w, "  IdentitiesOnly %s\n", h.IdentitiesOnly)
+		}
+		if h.IdentityAgent != "" {
+			_, _ = fmt.Fprintf(w, "  IdentityAgent %s\n", h.IdentityAgent)
 		}
 		for _, entry := range h.IdentityFile {
 			_, _ = fmt.Fprintf(w, "  IdentityFile %s\n", entry)


### PR DESCRIPTION
## What?

Support the `IdentityAgent` option in the configuration of hosts/templates/default

## Why?

When using multiple agents, for example in my case, the [Krypton](https://krypt.co/developers/) agent and the [Secretive](https://github.com/maxgoedjen/secretive) agent, it currently requires setting the agent for each host in the `.ssh/config` file manually (as far as I'm aware). This make things far simpler...


## Example

```
hosts:
  example-a:
    IdentityAgent: ~/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh

  example-b:
    Inherits: kr

templates:
  kr:
    IdentityAgent: ~/.kr/krd-agent.sock
    ProxyCommand: /opt/homebrew/bin/krssh -p "assh connect --port=%p %h" -h %h

```
