### PR TITLE
docs: add asdf installation into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,15 @@ Get a released version on: https://github.com/moul/assh/releases
 
 ---
 
+Install with [asdf-vm](https://asdf-vm.com/):
+```bash
+asdf plugin add assh
+asdf install assh latest
+asdf global assh latest
+```
+
+---
+
 ### Register the wrapper (optional)
 
 To improve experience when using advanced pattern matching, add the following at the end of your `.bashrc` / `.zshrc` / `config.fish`:


### PR DESCRIPTION
First of all - thanks for an awesome work you've made!

I've made an [asdf-vm](https://asdf-vm.com/) plugin for assh binary installation from GitHub releases.
The plugin was added to the official asdf repos, so it will be easy to use for asdf users.
If interested, you can find plugin source here - https://github.com/zekker6/asdf-assh

PR adds readme information about asdf way to install assh
