### PR TITLE
feat(window / git bash): Make assh work on Windows cmd and Git bash

### DIFF
--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"moul.io/assh/v2/pkg/utils"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,6 +44,8 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	abspath = filepath.ToSlash(abspath)
+	abspath = utils.EscapeSpaces(abspath)
 	config.SetASSHBinaryPath(abspath)
 
 	RootCmd.Flags().BoolP("help", "h", false, "print usage")

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -3,8 +3,14 @@ package utils
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 )
+
+// EscapeSpaces escapes all space characters with a backslash (\)
+func EscapeSpaces(s string) string {
+	return strings.ReplaceAll(s, " ", "\\ ")
+}
 
 // GetHomeDir returns '~' as a path
 func GetHomeDir() string {
@@ -42,14 +48,18 @@ func ExpandUser(path string) (string, error) {
 	// Expand variables
 	path = ExpandEnvSafe(path)
 
-	if path[:2] == "~/" {
+	if strings.HasPrefix(path, "~/") {
 		homeDir := GetHomeDir()
 		if homeDir == "" {
 			return "", errors.New("user home directory not found")
 		}
 
-		return strings.Replace(path, "~", homeDir, 1), nil
+		path = strings.Replace(path, "~", homeDir, 1)
 	}
+
+	path = filepath.FromSlash(path) // OS-agnostic slashes
+	path = EscapeSpaces(path)
+
 	return path, nil
 }
 

--- a/pkg/utils/env_test.go
+++ b/pkg/utils/env_test.go
@@ -2,10 +2,29 @@ package utils
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func TestEscapeSpaces(t *testing.T) {
+	Convey("Testing EscapeSpaces", t, func() {
+		So(EscapeSpaces("foo bar"), ShouldEqual, "foo\\ bar")
+		So(EscapeSpaces("/a/b c/d"), ShouldEqual, "/a/b\\ c/d")
+	})
+}
+
+func TestExpandEnvSafe(t *testing.T) {
+	Convey("Testing ExpandEnvSafe", t, func() {
+		So(os.Setenv("FOO", "bar"), ShouldBeNil)
+		So(ExpandEnvSafe("/a/$FOO/c"), ShouldEqual, "/a/bar/c")
+		So(ExpandEnvSafe("/a/${FOO}/c"), ShouldEqual, "/a/bar/c")
+		So(ExpandEnvSafe("/a/${FOO}/c/$FOO"), ShouldEqual, "/a/bar/c/bar")
+		So(ExpandEnvSafe("/a/$(FOO)/c"), ShouldEqual, "/a/$(FOO)/c")
+		So(ExpandEnvSafe(""), ShouldEqual, "")
+	})
+}
 
 func TestGetHomeDir(t *testing.T) {
 	Convey("Testing GetHomeDir", t, func() {
@@ -42,38 +61,46 @@ func TestGetHomeDir(t *testing.T) {
 }
 
 func TestExpandUser(t *testing.T) {
+	expected := "/a/b/c/test"
+	expectedEscaped := "/a/b/c/test\\ dir"
+
+	if runtime.GOOS == "windows" {
+		expected = "\\a\\b\\c\\test"
+		expectedEscaped = "\\a\\b\\c\\test\\ dir"
+	}
+
 	Convey("Testing ExpandUser", t, func() {
 		oldHome := os.Getenv("HOME")
 		oldUserProfile := os.Getenv("USERPROFILE")
 
 		So(os.Setenv("HOME", "/a/b/c"), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", ""), ShouldBeNil)
-		dir, err := ExpandUser("~/test")
-		So(dir, ShouldEqual, "/a/b/c/test")
+		dir, err := ExpandUser("~/test dir")
+		So(dir, ShouldEqual, expectedEscaped)
 		So(err, ShouldBeNil)
 
-		So(os.Setenv("HOME", "/a/b/d"), ShouldBeNil)
+		So(os.Setenv("HOME", "/a/b/c"), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", ""), ShouldBeNil)
 		dir, err = ExpandUser("~/test")
-		So(dir, ShouldEqual, "/a/b/d/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
-		So(os.Setenv("HOME", "/a/b/d"), ShouldBeNil)
+		So(os.Setenv("HOME", "/a/b/c"), ShouldBeNil)
+		So(os.Setenv("USERPROFILE", ""), ShouldBeNil)
+		dir, err = ExpandUser("~/test")
+		So(dir, ShouldEqual, expected)
+		So(err, ShouldBeNil)
+
+		So(os.Setenv("HOME", "/a/b/c"), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", "/a/b/e"), ShouldBeNil)
 		dir, err = ExpandUser("~/test")
-		So(dir, ShouldEqual, "/a/b/d/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", ""), ShouldBeNil)
-		So(os.Setenv("USERPROFILE", "/a/b/f"), ShouldBeNil)
+		So(os.Setenv("USERPROFILE", "/a/b/c"), ShouldBeNil)
 		dir, err = ExpandUser("~/test")
-		So(dir, ShouldEqual, "/a/b/f/test")
-		So(err, ShouldBeNil)
-
-		So(os.Setenv("HOME", ""), ShouldBeNil)
-		So(os.Setenv("USERPROFILE", "/a/b/g"), ShouldBeNil)
-		dir, err = ExpandUser("~/test")
-		So(dir, ShouldEqual, "/a/b/g/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", ""), ShouldBeNil)
@@ -85,25 +112,25 @@ func TestExpandUser(t *testing.T) {
 		So(os.Setenv("HOME", ""), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", ""), ShouldBeNil)
 		dir, err = ExpandUser("/a/b/c/test")
-		So(dir, ShouldEqual, "/a/b/c/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", "/e/f"), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", ""), ShouldBeNil)
 		dir, err = ExpandUser("/a/b/c/test")
-		So(dir, ShouldEqual, "/a/b/c/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", ""), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", "/e/g"), ShouldBeNil)
 		dir, err = ExpandUser("/a/b/c/test")
-		So(dir, ShouldEqual, "/a/b/c/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", "/e/h"), ShouldBeNil)
 		So(os.Setenv("USERPROFILE", "/e/i"), ShouldBeNil)
 		dir, err = ExpandUser("/a/b/c/test")
-		So(dir, ShouldEqual, "/a/b/c/test")
+		So(dir, ShouldEqual, expected)
 		So(err, ShouldBeNil)
 
 		So(os.Setenv("HOME", oldHome), ShouldBeNil)


### PR DESCRIPTION
Hey,

this should make `assh` work on Windows and Git Bash. Tested on:

- Windows CMD
- Git Bash
- Linus Bash

Changes made:

- https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-d0363058a4f070d48b66d99d1d7686d94275dde4e6be710648418dc82f44326cR47 ff. the main fix.
- https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-06c6a77af06580162abb68a7d2a311106d3e0ba9817ba9773ffaaa2540dd88c8R55 looks a little nicer to me.
- https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-06c6a77af06580162abb68a7d2a311106d3e0ba9817ba9773ffaaa2540dd88c8R55 is not really necessary but I started there and its does not seem to break things
- https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-d6450c77a46933ab113e7f678ebfa6d9149f4e27eaba2a864db3ad34f19325a2R11 took a detour but it was not necessary and I thought leaving the tests in there is a win anyway
-  https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-d6450c77a46933ab113e7f678ebfa6d9149f4e27eaba2a864db3ad34f19325a2R58 this was necessary to run (just these) tests locally @ Windows 
- https://github.com/moul/assh/compare/master...milkpirate:win?expand=1#diff-d6450c77a46933ab113e7f678ebfa6d9149f4e27eaba2a864db3ad34f19325a2R58 this was a duplicate of the test case before

Signed-off-by: Paul Schroeder <milkpirate@users.noreply.github.com>

