### PR TITLE
feat: Change go get to go install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ round-trip min/avg/max = 321µs/503.25µs/641µs
 Get the latest version using GO (recommended way):
 
 ```bash
-go get -u moul.io/assh/v2
+go install moul.io/assh/v2@latest
 ```
 
 **note**: tested with Go1.7 or above


### PR DESCRIPTION
`go get` is no longer a valid command outside of the module:

```bash
~ ❯ go get -u moul.io/assh/v2
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Instead, we should be using `go install`. Reflect this in the README
