### PR TITLE
fix: add goreleaser config.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,5 @@
+version: 2
+builds:
+  - ldflags:
+    - -X 'moul.io/assh/v2/pkg/version.Version={{.Version}}' 
+    - -X 'moul.io/assh/v2/pkg/version.VcsRef={{.Commit}}'


### PR DESCRIPTION
Need to set `version.Version` and `version.VcsRef` in ldflags when building with goreleaser, otherwise `--version` will output "n/a".

<!-- Thank you for contributing to this repo! I'm grateful for your support -->
