### PR TITLE
(host config): add MetaVars for custom inheritable variables in hooks

### DIFF
--- a/pkg/config/host.go
+++ b/pkg/config/host.go
@@ -129,6 +129,7 @@ type Host struct {
 	Comment               composeyaml.Stringorslice `yaml:"comment,omitempty,flow" json:"Comment,omitempty"`
 	RateLimit             string                    `yaml:"ratelimit,omitempty,flow" json:"RateLimit,omitempty"`
 	GatewayConnectTimeout int                       `yaml:"gatewayconnecttimeout,omitempty,flow" json:"GatewayConnectTimeout,omitempty"`
+	MetaVars              map[string]string         `yaml:"metavars,omitempty,flow" json:"MetaVars,omitempty"`
 
 	// private assh fields
 	noAutomaticRewrite bool
@@ -573,6 +574,9 @@ func (h *Host) prepare() {
 	}
 	for key, name := range h.Gateways {
 		h.Gateways[key] = strings.ToLower(name)
+	}
+	if h.MetaVars == nil {
+		h.MetaVars = make(map[string]string)
 	}
 }
 
@@ -1149,6 +1153,17 @@ func (h *Host) ApplyDefaults(defaults *Host) {
 	// Extra defaults
 	if h.Port == "" {
 		h.Port = "22"
+	}
+
+	// MetaVars inheritance: merge maps, child overrides parent
+	if h.MetaVars == nil {
+		h.MetaVars = make(map[string]string)
+	}
+	// copy defaults
+	for k, v := range defaults.MetaVars {
+		if _, exists := h.MetaVars[k]; !exists {
+			h.MetaVars[k] = v
+		}
 	}
 }
 


### PR DESCRIPTION
# what's improved
Currently, hooks can only access built-in host fields (e.g., `{{.Host.HostName}}`).
There is no built-in way to pass custom variables.
This feature allows for cleaner and more maintainable configurations, especially for dynamic hook commands such as notifications, tokens, passwords, and more.

## Details
- Added the `MetaVars map[string]string` field to the `Host` struct (`pkg/config/host.go`)
- Initialized in `Host.prepare()`
- Implemented inheritance in `ApplyDefaults()`
- No other changes to hook execution logic or anything else.

```
hosts:
  base-cisco-conf:
    user: admin
    port: 22
    setenv: term=xterm-256color
    controlmaster: auto
    controlpersist: 10m
    hooks:
      beforeconnect:  
      - 'exec ~/.local/bin/nmcli-vpn-up.sh {{.Host.MetaVars.vpn-name }}'
      - 'exec gopass show -c "{{.Host.MetaVars.gp-pass }}" '

  cisco-001:
    Inherits:
      - base-cisco-conf
    HostName: 192.168.1.254
    IdentityFile: ~/.ssh/id_6458
    MetaVars:
      vpn-name: "my-company-1"
      go-pass: "Work/my-company-1/cisco/001/pass"
```